### PR TITLE
AB#439638 Add polly retries for companies house

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 Functions to handle bulk upload of subsidiary data.
 
 
+## Retry policy
+
+Polly is used to retry http requests. Policies are added to http clients in the in the `ConfigurationExtensions` class.
+
+**Important** - if a timeout policy is used, the http client timeout should not be set in `AddHttpClient`, otherwise a `TaskCanceledException` will be thrown and not caught by the policy.
+There is some good information on this [here](https://briancaos.wordpress.com/2020/12/16/httpclient-retry-on-http-timeout-with-polly-and-ihttpclientbuilder/)
+
+
 ## Running on a developer machine
 To run locally, create a file `local.settings.json`. This file is in `.gitignore`.
 

--- a/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
@@ -30,7 +30,9 @@
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
 	  <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+	  <PackageReference Include="Polly" Version="8.4.1" />
   </ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EPR.SubsidiaryBulkUpload.Application\EPR.SubsidiaryBulkUpload.Application.csproj" />


### PR DESCRIPTION
Add polly policies for transient errors and timeouts, and use them on the companies house http clients to improve resilience.