### PR TITLE
AB#536457 remove old boomi certificate auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The structure of the application settings can be found in the repository. Exampl
 | ApiConfig__Timeout                                    | Number of seconds before timing out request to Accounts API                |
 | ApiConfig__CompaniesHouseLookupBaseUrl                | Url for the gateway to Companies House data                                |
 | ApiConfig__AccountServiceClientId                     | Accounts API client ID                                                     | 
-| ApiConfig__Certificate                                | Certificate for authenticating calls to the Companies House API gateway    |
 | ApiConfig__CompaniesHouseDirectBaseUri                | Url for direct access to Companies House data                              |
 | ApiConfig__CompaniesHouseDirectApiKey                 | API key for the Companies House API - used for direct access only          |
 | ApiConfig__UseDirectCompaniesHouseLookup              | Whether or not to access Companies House API directly                      |
@@ -46,7 +45,6 @@ The structure of the application settings can be found in the repository. Exampl
 | CompaniesHouseDownload__DownloadPage                  | The page used for downloading Companies House data                         |
 | CompaniesHouseDownload__RetryPolicyMaxRetries         | The number of times to retry failing calls to the Companies House downloads |
 | CompaniesHouseDownload__RetryPolicyInitialWaitTime    | The time to wait when calls to the Companies House downloads fail for the first time       |
-| FeatureManagement__UseBoomiOAuth                      | Feature flag used to determine whether OAuth should be used instead of a certificate  |
 | FeatureManagement__EnableSubsidiaryUploadJoinerColumns | Feature flag used to determine whether joiner or leavier columns should be included |
 | Redis__ConnectionString                               | Connection string for Redis                                                |
 | Redis__TimeToLiveInMinutes                            | Time to live (expiry) for Redis keysConnection string for Redis            |
@@ -109,8 +107,7 @@ To run locally, create a file `local.settings.json`. This file is in `.gitignore
     "SubmissionApi__BaseUrl": "https://localhost:7206",
     "TableStorage__ConnectionString": "UseDevelopmentStorage=true",
     "TableStorage__CompaniesHouseOfflineDataTableName": "CompaniesHouseData",
-    "FeatureManagement__EnableSubsidiaryUploadJoinerColumns": false,
-    "FeatureManagement__UseBoomiOAuth": true
+    "FeatureManagement__EnableSubsidiaryUploadJoinerColumns": false
   }
 }
 ```

--- a/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/EPR.SubsidiaryBulkUpload.Application.UnitTests.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/EPR.SubsidiaryBulkUpload.Application.UnitTests.csproj
@@ -12,22 +12,22 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
+    <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
 	<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
 	<PackageReference Include="System.Net.Http" Version="4.3.4" />
 	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/Services/CompaniesHouseLookupServiceTests.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/Services/CompaniesHouseLookupServiceTests.cs
@@ -1,12 +1,10 @@
 ﻿using System.Net;
 using System.Text.Json;
 using AutoFixture.AutoMoq;
-using EPR.SubsidiaryBulkUpload.Application.Constants;
 using EPR.SubsidiaryBulkUpload.Application.DTOs;
 using EPR.SubsidiaryBulkUpload.Application.Models;
 using EPR.SubsidiaryBulkUpload.Application.Services;
 using Microsoft.Extensions.Logging;
-using Microsoft.FeatureManagement;
 using Moq.Protected;
 
 namespace EPR.SubsidiaryBulkUpload.Application.UnitTests.Services;
@@ -14,14 +12,11 @@ namespace EPR.SubsidiaryBulkUpload.Application.UnitTests.Services;
 [TestClass]
 public class CompaniesHouseLookupServiceTests
 {
-    private const string CompaniesHouseEndpointForOAuth = "companies";
-    private const string CompaniesHouseEndpointForCertificateAuth = "CompaniesHouse/companies";
+    private const string CompaniesHouseEndpoint = "companies";
     private const string CompaniesHouseNumber = "0123456X";
     private const string BaseAddress = "http://localhost";
-    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpointForOAuth}/{CompaniesHouseNumber}";
-    private const string ExpectedUrlForCertificateAuth = $"{BaseAddress}/{CompaniesHouseEndpointForCertificateAuth}/{CompaniesHouseNumber}";
+    private const string ExpectedUrl = $"{BaseAddress}/{CompaniesHouseEndpoint}/{CompaniesHouseNumber}";
     private readonly IFixture _fixture = new Fixture().Customize(new AutoMoqCustomization());
-    private Mock<IFeatureManager> _featureManagerMock;
     private Mock<HttpMessageHandler> _httpMessageHandlerMock;
     private Mock<ILogger<CompaniesHouseLookupService>> _loggerMock;
 
@@ -29,12 +24,6 @@ public class CompaniesHouseLookupServiceTests
     public void TestInitialize()
     {
         _httpMessageHandlerMock = new();
-
-        _featureManagerMock = new();
-        _featureManagerMock
-            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
-            .ReturnsAsync(true);
-
         _loggerMock = new Mock<ILogger<CompaniesHouseLookupService>>();
     }
 
@@ -60,55 +49,7 @@ public class CompaniesHouseLookupServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object, _loggerMock.Object);
-
-        // Act
-        var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
-
-        // Assert
-        _httpMessageHandlerMock.Protected().Verify("SendAsync", Times.Once(), ItExpr.Is<HttpRequestMessage>(req => req.Method == HttpMethod.Get && req.RequestUri != null && req.RequestUri.ToString() == expectedUrl), ItExpr.IsAny<CancellationToken>());
-
-        result.Should().NotBeNull();
-        result.Name.Should().Be(apiResponse.Organisation.Name);
-        result.CompaniesHouseNumber.Should().Be(apiResponse.Organisation.RegistrationNumber);
-        result.AccountCreatedOn.Should().Be(apiResponse.AccountCreatedOn);
-
-        result.BusinessAddress.Should().NotBeNull();
-        result.BusinessAddress.Country.Should().Be(apiResponse.Organisation.RegisteredOffice?.Country?.Name);
-        result.BusinessAddress.County.Should().Be(apiResponse.Organisation.RegisteredOffice.County);
-        result.BusinessAddress.Town.Should().Be(apiResponse.Organisation.RegisteredOffice.Town);
-        result.BusinessAddress.Postcode.Should().Be(apiResponse.Organisation.RegisteredOffice.Postcode);
-        result.BusinessAddress.Street.Should().Be(apiResponse.Organisation.RegisteredOffice.Street);
-        result.BusinessAddress.Locality.Should().Be(apiResponse.Organisation.RegisteredOffice.Locality);
-    }
-
-    [TestMethod]
-    public async Task Should_Return_Correct_CompaniesHouseLookupResponse_WhenFeatureFlagIsOn()
-    {
-        // Arrange
-        _featureManagerMock
-            .Setup(x => x.IsEnabledAsync(FeatureFlags.UseBoomiOAuth))
-            .ReturnsAsync(false);
-
-        var apiResponse = _fixture.Create<CompaniesHouseResponse>();
-
-        var expectedUrl = ExpectedUrlForCertificateAuth;
-
-        _httpMessageHandlerMock.Protected()
-             .Setup<Task<HttpResponseMessage>>(
-                 "SendAsync",
-                 ItExpr.Is<HttpRequestMessage>(x => x.RequestUri != null && x.RequestUri.ToString() == expectedUrl),
-                 ItExpr.IsAny<CancellationToken>())
-             .ReturnsAsync(new HttpResponseMessage
-             {
-                 StatusCode = HttpStatusCode.OK,
-                 Content = new StringContent(JsonSerializer.Serialize(apiResponse))
-             }).Verifiable();
-
-        var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
-        httpClient.BaseAddress = new Uri(BaseAddress);
-
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object, _loggerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient, _loggerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
@@ -147,7 +88,7 @@ public class CompaniesHouseLookupServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object, _loggerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient, _loggerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
@@ -185,7 +126,7 @@ public class CompaniesHouseLookupServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object, _loggerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient, _loggerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);
@@ -223,7 +164,7 @@ public class CompaniesHouseLookupServiceTests
         var httpClient = new HttpClient(_httpMessageHandlerMock.Object);
         httpClient.BaseAddress = new Uri(BaseAddress);
 
-        var sut = new CompaniesHouseLookupService(httpClient, _featureManagerMock.Object, _loggerMock.Object);
+        var sut = new CompaniesHouseLookupService(httpClient, _loggerMock.Object);
 
         // Act
         var result = await sut.GetCompaniesHouseResponseAsync(CompaniesHouseNumber);

--- a/src/EPR.SubsidiaryBulkUpload.Application/Constants/FeatureFlags.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Constants/FeatureFlags.cs
@@ -2,6 +2,5 @@
 
 public static class FeatureFlags
 {
-    public const string UseBoomiOAuth = "UseBoomiOAuth";
     public const string EnableSubsidiaryJoinerColumns = "EnableSubsidiaryUploadJoinerColumns";
 }

--- a/src/EPR.SubsidiaryBulkUpload.Application/CsvReaderConfiguration/CsvConfigurations.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/CsvReaderConfiguration/CsvConfigurations.cs
@@ -22,7 +22,6 @@ public static class CsvConfigurations
                 {
                     csvReader.InvalidHeaderErrors = args.InvalidHeaders?.Select(x => x.Names[0]).ToList();
                 }
-            },
-            /* ShouldSkipRecord = record => record.Row..All(field => string.IsNullOrWhiteSpace(field)) */
+            }
         };
 }

--- a/src/EPR.SubsidiaryBulkUpload.Application/Options/ApiOptions.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Options/ApiOptions.cs
@@ -23,8 +23,6 @@ public class ApiOptions : ApiResilienceOptions
 
     public string TenantId { get; set; }
 
-    public string Certificate { get; set; } = null!;
-
     public int Timeout { get; set; }
 
     public string AccountServiceClientId { get; set; } = null!;

--- a/src/EPR.SubsidiaryBulkUpload.Application/Services/CompaniesHouseLookupService.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Services/CompaniesHouseLookupService.cs
@@ -1,33 +1,26 @@
 ﻿using System.Net;
 using System.Net.Http.Json;
-using EPR.SubsidiaryBulkUpload.Application.Constants;
 using EPR.SubsidiaryBulkUpload.Application.DTOs;
 using EPR.SubsidiaryBulkUpload.Application.Models;
 using EPR.SubsidiaryBulkUpload.Application.Services.Interfaces;
 using Microsoft.Extensions.Logging;
-using Microsoft.FeatureManagement;
 
 namespace EPR.SubsidiaryBulkUpload.Application.Services;
 public class CompaniesHouseLookupService : ICompaniesHouseLookupService
 {
+    private const string CompaniesHouseEndpoint = "companies";
+
     private readonly ILogger<CompaniesHouseLookupService> _logger;
     private readonly HttpClient _httpClient;
 
     public CompaniesHouseLookupService(
         HttpClient httpClient,
-        IFeatureManager featureManager,
         ILogger<CompaniesHouseLookupService> logger)
     {
         _httpClient = httpClient;
 
-        CompaniesHouseEndpoint = featureManager.IsEnabledAsync(FeatureFlags.UseBoomiOAuth).GetAwaiter().GetResult()
-            ? "companies"
-            : "CompaniesHouse/companies";
-
         _logger = logger;
     }
-
-    private string CompaniesHouseEndpoint { get; init; }
 
     public async Task<Company?> GetCompaniesHouseResponseAsync(string id)
     {

--- a/src/EPR.SubsidiaryBulkUpload.Function.UnitTests/EPR.SubsidiaryBulkUpload.Function.UnitTests.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function.UnitTests/EPR.SubsidiaryBulkUpload.Function.UnitTests.csproj
@@ -13,20 +13,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="ILogger.Moq" Version="1.1.10" />
+    <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
+    <PackageReference Include="ILogger.Moq" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
@@ -23,7 +23,7 @@
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.6.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
-	  <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+	  <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
 	  <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />

--- a/src/EPR.SubsidiaryBulkUpload.Function/settings.json
+++ b/src/EPR.SubsidiaryBulkUpload.Function/settings.json
@@ -34,7 +34,6 @@
     "SubmissionApi__BaseUrl": "https://localhost:7206",
     "TableStorage__ConnectionString": "UseDevelopmentStorage=true",
     "TableStorage__CompaniesHouseOfflineDataTableName": "CompaniesHouseData",
-    "FeatureManagement__EnableSubsidiaryUploadJoinerColumns": false,
-    "FeatureManagement__UseBoomiOAuth": false
+    "FeatureManagement__EnableSubsidiaryUploadJoinerColumns": false
   }
 }


### PR DESCRIPTION
Removed old Boomi certificate configuration and feature flag, which are no longer needed because migration to OAuth is now complete.

Other changes:
 - updated a deprecated nuget package `Microsoft.ApplicationInsights.WorkerService` and several testing packages.
 - updated testing nuget packages
 - updated and locked `FluentAssertions` to version '7.2.0' which is the last non-commercial version