### PR TITLE
Update Microsoft.Identity.Web to fix restore. AB#536457

### DIFF
--- a/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
@@ -25,7 +25,7 @@
   <PackageReference Include="Polly" Version="8.4.2" />
   <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
   <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-  <PackageReference Include="Microsoft.Identity.Web" Version="3.3.0" />
+  <PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
   <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Build was broken due to package vulnerability