### PR TITLE
SUB-272: Upgrade to .NET 10 and migrate CI to GitHub pipeline templates

### DIFF
--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -41,8 +41,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 extends:

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -36,7 +36,7 @@ variables:
   - name: runTests
     value: true
   - name: dotnetVersion
-    value: dotnetVersion8
+    value: dotnetVersion10
 
 resources:
   repositories:

--- a/pipelines/ci_pipeline.yaml
+++ b/pipelines/ci_pipeline.yaml
@@ -17,7 +17,7 @@ parameters:
     # - 'SonarQubeLatest'
 
 
-pool: DEFRA-COMMON-ubuntu2004-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 
 variables:
   - template: vars/DEV4-development.yaml

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -1,6 +1,6 @@
 trigger: none
 pr: none
-pool: DEFRA-COMMON-ubuntu2204-SSV3
+pool: DEFRA-COMMON-UBUNTU-SSV3
 appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 
@@ -13,7 +13,6 @@ parameters:
     - DEV1
     - DEV2
     - DEV3
-    - DEV5
     - DEV6
     - DEV7
     - DEV8

--- a/pipelines/vars/DEV5-development.yaml
+++ b/pipelines/vars/DEV5-development.yaml
@@ -1,6 +1,0 @@
-variables:
-  azureSubscription: 'AZD-RWD-DEV5'
-  docker.imageName: 'subsidiaryupload'
-  acr.azureContainerRegistryName: 'devrwdinfac1401'
-  acr.repositoryName: 'subsidiaryuploadrepository'
-  serviceName: 'DEVRWDWEBFA5408'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/EPR.SubsidiaryBulkUpload.Application.UnitTests.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Application.UnitTests/EPR.SubsidiaryBulkUpload.Application.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -22,14 +22,13 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="ILogger.Moq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-	<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+	<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
-	<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -17,17 +17,13 @@
   <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
   <PackageReference Include="MagicMapper" Version="14.0.1" />
   <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
-  <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
-  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
-  <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
   <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
   <PackageReference Include="Polly" Version="8.4.2" />
   <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
-  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   <PackageReference Include="Microsoft.Identity.Web" Version="3.8.3" />
   <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Application/EPR.SubsidiaryBulkUpload.Application.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
   <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  <PackageReference Include="AutoMapper" Version="13.0.1" />
   <PackageReference Include="Azure.Core" Version="1.44.1" />
   <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
   <PackageReference Include="Azure.Identity" Version="1.13.1" />
@@ -16,6 +15,7 @@
   <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
   <PackageReference Include="CsvHelper" Version="33.0.1" />
   <PackageReference Include="HtmlAgilityPack" Version="1.11.70" />
+  <PackageReference Include="MagicMapper" Version="14.0.1" />
   <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
   <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
   <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />

--- a/src/EPR.SubsidiaryBulkUpload.Application/Services/BulkSubsidiaryProcessor.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Services/BulkSubsidiaryProcessor.cs
@@ -39,7 +39,7 @@ public class BulkSubsidiaryProcessor(ISubsidiaryService organisationService, ICo
 
         var subsidiariesAndOrg = await nonNullCompaniesHouseNumberRecords
             .ToAsyncEnumerable()
-            .SelectAwait(async subsidiary => (Subsidiary: subsidiary, SubsidiaryOrg: await organisationService.GetCompanyByCompaniesHouseNumber(subsidiary.companies_house_number)))
+            .Select(async (CompaniesHouseCompany subsidiary, CancellationToken ct) => (Subsidiary: subsidiary, SubsidiaryOrg: await organisationService.GetCompanyByCompaniesHouseNumber(subsidiary.companies_house_number)))
             .ToListAsync();
 
         var subsidiariesAndOrgWithValidNameProcessStatistics = await ProcessValidNamedOrgs(subsidiariesAndOrg, parentOrg, userRequestModel);
@@ -70,7 +70,7 @@ public class BulkSubsidiaryProcessor(ISubsidiaryService organisationService, ICo
         /*Scenario 3: The subsidiary found in Offline data. name matches then Add OR name not match then get it from CH API and name matches with CH API data.*/
         var newSubsidiariesToAdd_DataFromLocalStorageOrCH = subsidiariesAndOrg.Where(co => co.SubsidiaryOrg == null)
             .ToAsyncEnumerable()
-            .SelectAwait(async subsidiary =>
+            .Select(async ((CompaniesHouseCompany Subsidiary, OrganisationResponseModel SubsidiaryOrg) subsidiary, CancellationToken ct) =>
                 (Subsidiary: subsidiary.Subsidiary, LinkModel: await GetLinkModelForCompaniesHouseData(subsidiary.Subsidiary, parentOrg, userRequestModel.UserId)))
             .Where(subAndLink => subAndLink.LinkModel != null);
 
@@ -216,7 +216,7 @@ public class BulkSubsidiaryProcessor(ISubsidiaryService organisationService, ICo
         // companies with franchisee flag.
         var companiesWithFranchiseeFlagRecords = subsidiaries.Where(ch => ch.franchisee_licensee_tenant == "Y")
             .ToAsyncEnumerable()
-            .SelectAwait(async subsidiary => (Subsidiary: subsidiary, SubsidiaryOrg: await organisationService.GetCompanyByCompanyName(subsidiary.organisation_name)));
+            .Select(async (CompaniesHouseCompany subsidiary, CancellationToken ct) => (Subsidiary: subsidiary, SubsidiaryOrg: await organisationService.GetCompanyByCompanyName(subsidiary.organisation_name)));
 
         // check if the incoming file company name is matching with the one in db. name to match.
         var subsidiariesAndOrgExistsInTheDB = companiesWithFranchiseeFlagRecords
@@ -225,7 +225,7 @@ public class BulkSubsidiaryProcessor(ISubsidiaryService organisationService, ICo
             && NullOrEmptyStringEqualityComparer.CaseInsensitiveComparer.Equals(sub.Subsidiary.companies_house_number, sub.SubsidiaryOrg.companiesHouseNumber));
 
         var knownFranchiseeToAddRelationship = subsidiariesAndOrgExistsInTheDB.Where(co => co.SubsidiaryOrg != null)
-          .SelectAwait(async co =>
+          .Select(async ((CompaniesHouseCompany Subsidiary, OrganisationResponseModel SubsidiaryOrg) co, CancellationToken ct) =>
               (Subsidiary: co.Subsidiary,
                SubsidiaryOrg: co.SubsidiaryOrg,
                RelationshipExists: await organisationService.GetSubsidiaryRelationshipAsync(parentOrg.id, co.SubsidiaryOrg.id)))
@@ -327,7 +327,7 @@ public class BulkSubsidiaryProcessor(ISubsidiaryService organisationService, ICo
 
         var knownSubsidiariesToAddCheck = await subsidiariesAndOrgWithValidName.Where(co => co.SubsidiaryOrg != null)
         .ToAsyncEnumerable()
-        .SelectAwait(async co =>
+        .Select(async ((CompaniesHouseCompany Subsidiary, OrganisationResponseModel SubsidiaryOrg) co, CancellationToken ct) =>
             (Subsidiary: co.Subsidiary,
              SubsidiaryOrg: co.SubsidiaryOrg,
              RelationshipExists: await organisationService.GetSubsidiaryRelationshipAsync(parentOrg.id, co.SubsidiaryOrg.id))).ToListAsync();

--- a/src/EPR.SubsidiaryBulkUpload.Application/Services/BulkUploadOrchestration.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Services/BulkUploadOrchestration.cs
@@ -89,8 +89,8 @@ public class BulkUploadOrchestration : IBulkUploadOrchestration
         var subsidiaryGroupsWithValidParents = subsidiaryGroups.Where(p => p.Parent.organisation_name != "orphan");
 
         // this will fetch data from the org database for all the parents and filter to keep the valid ones (org exists in RPD)
-        var subsidiaryGroupsAndParentOrg = await subsidiaryGroupsWithValidParents.SelectAwait(
-            async sg => (SubsidiaryGroup: sg, parentOrg: await _organisationService.GetCompanyByReferenceNumber(sg.Parent.organisation_id))).ToListAsync();
+        var subsidiaryGroupsAndParentOrg = await subsidiaryGroupsWithValidParents.Select(
+            async (ParentAndSubsidiaries sg, CancellationToken ct) => (SubsidiaryGroup: sg, parentOrg: await _organisationService.GetCompanyByReferenceNumber(sg.Parent.organisation_id))).ToListAsync();
 
         // filter the non CS parents
         var dataRefinedAfterNonComplianceSchemeFilter = await FilterNonComplianceSchemeParentSubsidiaries(userRequestModel, subsidiaryGroupsAndParentOrg);

--- a/src/EPR.SubsidiaryBulkUpload.Application/Services/NotificationService.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Services/NotificationService.cs
@@ -46,7 +46,7 @@ public class NotificationService(
             }
             else
             {
-                var response = JsonSerializer.Deserialize<UploadFileErrorResponse>(previousErrors, _caseInsensitiveJsonSerializerOptions);
+                var response = JsonSerializer.Deserialize<UploadFileErrorResponse>(previousErrors.ToString(), _caseInsensitiveJsonSerializerOptions);
                 errors = response.Errors;
                 errors.AddRange(errorsModel);
             }
@@ -77,7 +77,7 @@ public class NotificationService(
 
         _logger.LogInformation("Redis errors response key: {Key} errors: {Value}", key, value);
 
-        return JsonSerializer.Deserialize<UploadFileErrorResponse>(value, _caseInsensitiveJsonSerializerOptions);
+        return JsonSerializer.Deserialize<UploadFileErrorResponse>(value.ToString(), _caseInsensitiveJsonSerializerOptions);
     }
 
     public async Task ClearRedisKeyAsync(string key)

--- a/src/EPR.SubsidiaryBulkUpload.Application/Services/TableStorageProcessor.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Application/Services/TableStorageProcessor.cs
@@ -125,12 +125,11 @@ public class TableStorageProcessor(
                     select: new List<string> { "PartitionKey", "RowKey" },
                     maxPerPage: 1000);
 
-            await entities.AsPages()
-                .ForEachAwaitAsync(async page =>
-                {
-                    var responses = await BatchManipulateEntities(tableClient, page.Values, TableTransactionActionType.Delete).ConfigureAwait(false);
-                    deleted += responses.Sum(response => response?.Value?.Count ?? 0);
-                });
+            await foreach (var page in entities.AsPages())
+            {
+                var responses = await BatchManipulateEntities(tableClient, page.Values, TableTransactionActionType.Delete).ConfigureAwait(false);
+                deleted += responses.Sum(response => response?.Value?.Count ?? 0);
+            }
         }
         catch (RequestFailedException fex)
         {

--- a/src/EPR.SubsidiaryBulkUpload.Function.UnitTests/EPR.SubsidiaryBulkUpload.Function.UnitTests.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function.UnitTests/EPR.SubsidiaryBulkUpload.Function.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -27,6 +27,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Function/Dockerfile
+++ b/src/EPR.SubsidiaryBulkUpload.Function/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS installer-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS installer-env
 
 # Copy everything
 COPY NuGet.Config ./
@@ -12,7 +12,7 @@ COPY EPR.SubsidiaryBulkUpload.Function/. ./EPR.SubsidiaryBulkUpload.Function/.
 RUN dotnet publish EPR.SubsidiaryBulkUpload.Function/*.csproj --output /home/site/wwwroot
 
 # Use the Azure Functions image as the final image
-FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated10.0
 
 # Create a non-root user and set permissions
 RUN groupadd -r dotnet && \

--- a/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Suppress grcp compatibility warning. See https://learn.microsoft.com/en-gb/dotnet/core/resilience/http-resilience?tabs=dotnet-cli#known-issues -->
     <SuppressCheckGrpcNetClientFactoryVersion>true</SuppressCheckGrpcNetClientFactoryVersion>
-    <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>a996cd13-8208-4a47-9602-f9f3ebf431b5</UserSecretsId>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
@@ -44,7 +41,7 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
       <None Update="local.settings.json">
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </None>
   </ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
@@ -10,6 +10,7 @@
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>a996cd13-8208-4a47-9602-f9f3ebf431b5</UserSecretsId>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
 	  <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
+++ b/src/EPR.SubsidiaryBulkUpload.Function/EPR.SubsidiaryBulkUpload.Function.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -17,18 +17,17 @@
 	  <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
 	  <PackageReference Include="CsvHelper" Version="33.0.1" />
 	  <PackageReference Include="CsvValidator" Version="1.0.4" />
-	  <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
+	  <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.6.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+	  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
 	  <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
 	  <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
 	  <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.6" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
-	  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 	  <PackageReference Include="Polly" Version="8.4.2" />
   </ItemGroup>

--- a/src/EPR.SubsidiaryBulkUpload.Function/HealthCheckFunction.cs
+++ b/src/EPR.SubsidiaryBulkUpload.Function/HealthCheckFunction.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace EPR.SubsidiaryBulkUpload.Function;
+
+[ExcludeFromCodeCoverage(Justification = "A simple health check")]
+public static class HealthCheckFunction
+{
+    [Function("HealthCheck")]
+    public static async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "health")] HttpRequestData req)
+    {
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        var healthStatus = new { Status = "Healthy", Timestamp = DateTime.UtcNow };
+
+        await response.WriteAsJsonAsync(healthStatus);
+
+        return response;
+    }
+}

--- a/src/EPR.SubsidiaryBulkUpload.Function/Properties/launchSettings.json
+++ b/src/EPR.SubsidiaryBulkUpload.Function/Properties/launchSettings.json
@@ -3,13 +3,6 @@
     "EPR.SubsidiaryBulkUpload.Function": {
       "commandName": "Project",
       "commandLineArgs": "--port 7245"
-    },
-    "Container (Dockerfile)": {
-      "commandName": "Docker",
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
-      "DockerfileRunArguments": "--init",
-      "httpPort": 31690,
-      "useSSL": false
     }
   }
 }


### PR DESCRIPTION
SUB-272: Upgrade to .NET 10 and migrate CI to GitHub pipeline templates

- Upgrades the function app and all projects to .NET 10
- Replaces `Community.AutoMapper` with `MagicMapper` 14.0.1
- Repoints the CI pipeline to the shared GitHub pipeline templates and bumps the build agent version
- Adds an anonymous `/health` HTTP-triggered health check endpoint
- Removes the discontinued DEV5 environment from the deployment pipeline

- Upgrades the function app and all projects to .NET 10
- Replaces `Community.AutoMapper` with `MagicMapper` 14.0.1
- Repoints the CI pipeline to the shared GitHub pipeline templates and bumps the build agent version
- Adds an anonymous `/health` HTTP-triggered health check endpoint
- Removes the discontinued DEV5 environment from the deployment pipeline

- "SelectAwait" and "ForEachAwaitAsync" removed from the newer .NET10 libraries and so replaced with working alternatives